### PR TITLE
Fix Twitter image exclusion: don't exclude images with 'small' in que…

### DIFF
--- a/backend/scrapers/twitter.py
+++ b/backend/scrapers/twitter.py
@@ -186,10 +186,12 @@ async def scrape_with_playwright(url: str) -> Optional[Dict]:
                             # Enhanced filtering - be more specific about what to exclude
                             exclude_patterns = [
                                 "profile", "avatar", "icon", "normal", "bigger", "mini",
-                                "verified", "badge", "emoji", "sticker", "small"
+                                "verified", "badge", "emoji", "sticker"
                             ]
                             
-                            should_exclude = any(pattern in src.lower() for pattern in exclude_patterns)
+                            # Check for exclusion patterns in the URL path, not query params
+                            url_path = src.split('?')[0].lower()
+                            should_exclude = any(pattern in url_path for pattern in exclude_patterns)
                             
                             # Also exclude very small images (likely icons)
                             if len(src) < 100:
@@ -230,13 +232,14 @@ async def scrape_with_playwright(url: str) -> Optional[Dict]:
 
                             if src and src.startswith("http"):
                                 # Filter out profile images and small icons
+                                url_path = src.split('?')[0].lower()
                                 if (
-                                    "profile" in src
-                                    or "avatar" in src
-                                    or "icon" in src
-                                    or "normal" in src
-                                    or "bigger" in src
-                                    or "mini" in src
+                                    "profile" in url_path
+                                    or "avatar" in url_path
+                                    or "icon" in url_path
+                                    or "normal" in url_path
+                                    or "bigger" in url_path
+                                    or "mini" in url_path
                                     or len(src) < 80
                                 ):  # Skip very short URLs
                                     continue

--- a/backend/test_twitter_image_fix_v2.py
+++ b/backend/test_twitter_image_fix_v2.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from scrapers.twitter import TwitterScraper
+
+def test_twitter_image_extraction_fix():
+    """Test that Twitter posts with images containing 'small' parameter get proper thumbnails"""
+    
+    # Test URL from the user's example
+    test_url = "https://x.com/birdabo404/status/1946610855480881610"
+    
+    scraper = TwitterScraper()
+    
+    print(f"🧪 Testing URL: {test_url}")
+    print("=" * 60)
+    
+    try:
+        result = scraper.scrape(test_url)
+        
+        print(f"📊 Results:")
+        print(f"   Title: {result.get('title', 'N/A')}")
+        print(f"   Description: {result.get('description', 'N/A')}")
+        print(f"   Thumbnail: {result.get('thumbnail', 'N/A')}")
+        print(f"   Type: {result.get('type', 'N/A')}")
+        print(f"   Platform: {result.get('platform', 'N/A')}")
+        
+        # Check if thumbnail was found
+        thumbnail = result.get('thumbnail')
+        if thumbnail:
+            print(f"✅ SUCCESS: Thumbnail found: {thumbnail}")
+            return True
+        else:
+            print(f"❌ FAILED: No thumbnail found")
+            return False
+            
+    except Exception as e:
+        print(f"❌ ERROR: {e}")
+        return False
+
+if __name__ == "__main__":
+    test_twitter_image_extraction_fix() 


### PR DESCRIPTION
…ry params

- Removed 'small' from exclusion patterns
- Changed filtering to check URL path only, not query parameters
- Twitter image URLs often contain 'name=small' but this doesn't mean they're small icons
- Fixed both embedded image detection and broader search logic
- Added test script for the specific problematic case